### PR TITLE
Update to support Elasticsearch.Net and NEST v5.0.0-rc4

### DIFF
--- a/src/ElasticIdentity.Tests/ElasticIdentity.Tests.csproj
+++ b/src/ElasticIdentity.Tests/ElasticIdentity.Tests.csproj
@@ -34,8 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Elasticsearch.Net.2.3.1\lib\net46\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Elasticsearch.Net.5.0.0-rc4\lib\net46\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -43,12 +43,12 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NEST.2.3.1\lib\net46\Nest.dll</HintPath>
+    <Reference Include="Nest, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NEST.5.0.0-rc4\lib\net46\Nest.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/ElasticIdentity.Tests/packages.config
+++ b/src/ElasticIdentity.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="2.3.1" targetFramework="net46" />
+  <package id="Elasticsearch.Net" version="5.0.0-rc4" targetFramework="net46" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net46" />
-  <package id="NEST" version="2.3.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net46" />
+  <package id="NEST" version="5.0.0-rc4" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net46" />

--- a/src/ElasticIdentity/ElasticClaim.cs
+++ b/src/ElasticIdentity/ElasticClaim.cs
@@ -33,10 +33,10 @@ namespace ElasticIdentity
 {
 	public class ElasticClaim : IEquatable<ElasticClaim>
 	{
-        [String( Index = FieldIndexOption.NotAnalyzed, DocValues = true, IncludeInAll = false )]
+        [Keyword(IncludeInAll = false )]
         public string Type { get; set; }
 
-        [String( Index = FieldIndexOption.NotAnalyzed, DocValues = true, IncludeInAll = false )]
+        [Keyword(IncludeInAll = false )]
         public string Value { get; set; }
 
 		public ElasticClaim()

--- a/src/ElasticIdentity/ElasticIdentity.csproj
+++ b/src/ElasticIdentity/ElasticIdentity.csproj
@@ -42,8 +42,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Elasticsearch.Net.2.3.1\lib\net46\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Elasticsearch.Net.5.0.0-rc4\lib\net46\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -51,12 +51,12 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NEST.2.3.1\lib\net46\Nest.dll</HintPath>
+    <Reference Include="Nest, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NEST.5.0.0-rc4\lib\net46\Nest.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/ElasticIdentity/ElasticUser.cs
+++ b/src/ElasticIdentity/ElasticUser.cs
@@ -68,18 +68,18 @@ namespace ElasticIdentity
             set { _version = value; }
         }
 
-        [String( Index = FieldIndexOption.Analyzed, Analyzer = "lowercaseKeyword" )]
+        [Text(Analyzer = "lowercaseKeyword" )]
         public string UserName
 		{
 			get { return _userName; }
 			set { _userName = value?.ToLowerInvariant(); }
 		}
 
-        [String( Index = FieldIndexOption.NotAnalyzed, DocValues = true, IncludeInAll = false )]
+        [Keyword(IncludeInAll = false )]
         [JsonProperty( DefaultValueHandling = DefaultValueHandling.Ignore )]
 		public string PasswordHash { get; set; }
 
-        [String( Index = FieldIndexOption.NotAnalyzed, DocValues = true, IncludeInAll = false )]
+        [Keyword(IncludeInAll = false )]
         [JsonProperty( DefaultValueHandling = DefaultValueHandling.Ignore )]
 		public string SecurityStamp { get; set; }
 

--- a/src/ElasticIdentity/ElasticUserEmail.cs
+++ b/src/ElasticIdentity/ElasticUserEmail.cs
@@ -4,7 +4,7 @@ namespace ElasticIdentity
 {
 	public class ElasticUserEmail : ElasticUserConfirmed
 	{
-        [String( Index = FieldIndexOption.NotAnalyzed, DocValues = true, IncludeInAll = false )]
+        [Keyword(IncludeInAll = false )]
         public string Address { get; set; }
 	}
 }

--- a/src/ElasticIdentity/ElasticUserLoginInfo.cs
+++ b/src/ElasticIdentity/ElasticUserLoginInfo.cs
@@ -31,10 +31,10 @@ namespace ElasticIdentity
 {
 	public class ElasticUserLoginInfo
 	{
-        [String( Index = FieldIndexOption.NotAnalyzed, DocValues = true, IncludeInAll = false )]
+        [Keyword(IncludeInAll = false )]
         public string LoginProvider { get; set; }
 
-        [String( Index = FieldIndexOption.NotAnalyzed, DocValues = true, IncludeInAll = false )]
+        [Keyword(IncludeInAll = false )]
         public string ProviderKey { get; set; }
 	}
 }

--- a/src/ElasticIdentity/ElasticUserPhone.cs
+++ b/src/ElasticIdentity/ElasticUserPhone.cs
@@ -4,7 +4,7 @@ namespace ElasticIdentity
 {
 	public class ElasticUserPhone : ElasticUserConfirmed
 	{
-        [String( Index = FieldIndexOption.NotAnalyzed, DocValues = true, IncludeInAll = false )]
+        [Keyword(DocValues = true, IncludeInAll = false )]
         public string Number { get; set; }
 	}
 }

--- a/src/ElasticIdentity/ElasticUserStore.cs
+++ b/src/ElasticIdentity/ElasticUserStore.cs
@@ -164,16 +164,16 @@ namespace ElasticIdentity
             {
                 Wrap(await Client.IndexAsync(user, x => x
                   .OpType(OpType.Create)
-                  .Consistency(Consistency.Quorum)
-                  .Refresh()));
+                  //.Consistency(Consistency.Quorum)
+                  .Refresh(Refresh.True)));
             }
             else
             {
                 Wrap(await Client.IndexAsync(user, x => x
                   .OpType(OpType.Index)
                   .Version(user.Version)
-                  .Consistency(Consistency.Quorum)
-                  .Refresh()));
+                  //.Consistency(Consistency.Quorum)
+                  .Refresh(Refresh.True)));
             }
         }
 
@@ -201,9 +201,9 @@ namespace ElasticIdentity
             if (user == null) throw new ArgumentNullException(nameof(user));
 
             Wrap(await Client.DeleteAsync(DocumentPath<TUser>.Id(user.Id), d => d
-                .Consistency(Consistency.Quorum)
+                //.Consistency(Consistency.Quorum)
                 .Version(user.Version)
-                .Refresh()));
+                .Refresh(Refresh.True)));
         }
 
         public async Task<TUser> FindByIdAsync(string userId)

--- a/src/ElasticIdentity/packages.config
+++ b/src/ElasticIdentity/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="2.3.1" targetFramework="net46" />
+  <package id="Elasticsearch.Net" version="5.0.0-rc4" targetFramework="net46" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net46" />
-  <package id="NEST" version="2.3.1" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net46" />
+  <package id="NEST" version="5.0.0-rc4" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
- Updated Package references of Elasticsearch.Net and NEST to v5.0.0-rc4
- Changed types from String to Keyword and Text where appropriate
- Removed .Consistency() in IndexAsync (no longer supported?)